### PR TITLE
Fix Laravel ^5.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,19 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - XX-XX-XXXX
+## [1.0.0] - 17-03-2020
 ### Added
-- List Changes
+- EVERYTHING.
 ### Changed
-- List Changes
+- N/A
 ### Removed
-- List Changes
+- N/A
+
+## [1.0.1] - 17-03-2020
+### Added
+- N/A
+### Changed
+- Use `has()` to deal with the return type hint.
+- Update tests to not use the cache helper.
+### Removed
+- N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 - Use `has()` to deal with the return type hint.
 - Update tests to not use the cache helper.
+- Use `Carbon::createFromTimestamp` instead of `Carbon::parse()` for testing timestamp.
 ### Removed
 - N/A

--- a/src/Cache/Manager.php
+++ b/src/Cache/Manager.php
@@ -28,6 +28,8 @@ class Manager
 
     public function store(string $token, int $expiry): bool
     {
-        return $this->cache->put(self::CACHE_KEY, encrypt($token), $expiry - 10);
+        $this->cache->put(self::CACHE_KEY, encrypt($token), $expiry - 10);
+
+        return $this->cache->has(self::CACHE_KEY);
     }
 }

--- a/tests/Feature/FacadeTest.php
+++ b/tests/Feature/FacadeTest.php
@@ -11,7 +11,7 @@ class FacadeTest extends TestCase
     /** @test */
     public function it_can_get_the_access_token_via_the_facade(): void
     {
-        cache()->put(Manager::CACHE_KEY, encrypt('1234'));
+        app(Manager::class)->store('1234', 85000);
 
         $result = HereOAuth::getToken();
 

--- a/tests/Feature/HelperTest.php
+++ b/tests/Feature/HelperTest.php
@@ -5,12 +5,12 @@ namespace Laralabs\HereOAuth\Tests\Feature;
 use Laralabs\HereOAuth\Cache\Manager;
 use Laralabs\HereOAuth\Tests\TestCase;
 
-class HelperMethodTest extends TestCase
+class HelperTest extends TestCase
 {
     /** @test */
     public function it_can_run_the_helper_function_and_get_an_access_token_back(): void
     {
-        cache()->put(Manager::CACHE_KEY, encrypt('1234'));
+        app(Manager::class)->store('1234', 85000);
 
         $result = getHereApiToken();
 

--- a/tests/Unit/Cache/ManagerTest.php
+++ b/tests/Unit/Cache/ManagerTest.php
@@ -29,21 +29,21 @@ class ManagerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_retrieve_a_stored_access_token_from_the_cache(): void
-    {
-        cache()->put(Manager::CACHE_KEY, encrypt('1234'), 85000);
-
-        $result = $this->manager->retrieve();
-
-        $this->assertEquals('1234', $result);
-    }
-
-    /** @test */
     public function it_can_store_an_encrypted_access_token_in_the_cache(): void
     {
         $this->manager->store('1234', 85000);
 
         $this->assertNotEquals('1234', cache(Manager::CACHE_KEY));
         $this->assertEquals('1234', decrypt(cache(Manager::CACHE_KEY)));
+    }
+
+    /** @test */
+    public function it_can_retrieve_a_stored_access_token_from_the_cache(): void
+    {
+        $this->manager->store('1234', 85000);
+
+        $result = $this->manager->retrieve();
+
+        $this->assertEquals('1234', $result);
     }
 }

--- a/tests/Unit/Factories/OAuthHeaderTest.php
+++ b/tests/Unit/Factories/OAuthHeaderTest.php
@@ -87,7 +87,7 @@ class OAuthHeaderTest extends TestCase
 
         $timestamp = $this->header->getTimestamp();
 
-        $this->assertEquals('16-03-2020 13:00', Carbon::parse($timestamp)->format('d-m-Y H:i'));
+        $this->assertEquals('16-03-2020 13:00', Carbon::createFromTimestamp($timestamp)->format('d-m-Y H:i'));
     }
 
     /** @test */


### PR DESCRIPTION
- Use `has()` to deal with the return type hint.
- Update tests to not use the cache helper.